### PR TITLE
Fix: sorted the problem lists by ID in descending order

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,6 +65,7 @@ def generate_problem_list_pages(problem_dict, stats, output_dir='web-page'):
             point_int = int(float(point))
             for color, problem_ids in color_dict.items():
                 items = []
+                problem_ids.sort(reverse=True)
                 for pid in problem_ids:
                     # Find contest_id for this problem_id
                     contest_id = None


### PR DESCRIPTION
I modified main.py to sort `problem_ids` in reverse order before generating the HTML for problem list pages. This addresses the issue where lists of problems for a specific score and color were previously sorted in ascending order of problem ID.